### PR TITLE
Refine festival page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# FukuokaYakuinExpo
+# Fukuoka Yakuin Expo
+
+This repository contains a sample website for a campus festival.
+
+Open `index.html` in a browser to view the demo. The CSS and JavaScript
+files are located in the `css` and `js` folders respectively.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,58 @@
+body {
+  font-family: "Noto Sans JP", sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f8f8f8;
+  color: #333;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+
+header.top {
+  background: #0d5cab;
+  color: #fff;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+nav a.active {
+  border-bottom: 2px solid #fff;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+section {
+  background: #fff;
+  margin: 1rem auto;
+  padding: 1rem 2rem;
+  max-width: 800px;
+  border-radius: 4px;
+}
+
+.plan_introduction > div {
+  margin-bottom: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #0d5cab;
+  color: #fff;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>福岡薬院万博(キャンフェス）</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script>
+    (function(d) {
+      var config = {
+          kitId: 'ate1cnz',
+          scriptTimeout: 3000,
+          async: true
+        },
+        h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+    })(document);
+  </script>
+</head>
+<body>
+<header class="top">
+  <h1>福岡薬院キャンフェスサイト</h1>
+  <nav>
+    <ul>
+      <li><a href="#theme">テーマ</a></li>
+      <li><a href="#detail">開催概要</a></li>
+      <li><a href="#plan">企画紹介</a></li>
+      <li><a href="#timetable">タイムテーブル</a></li>
+    </ul>
+  </nav>
+</header>
+<main>
+<section id="theme" class="theme">
+  <h3>今年のキャンフェステーマは</h3>
+  <h2>福岡薬院万博</h2>
+  <h3>になりました！！</h3>
+</section>
+
+<section id="detail" class="detail">
+  <h2>開催概要</h2>
+  <h3>2025年9月20日(土)<br>オープニング12:00(開場11:30)<br>＠N/S/R高福岡薬院キャンパス</h3>
+</section>
+
+<section id="about" class="how_to_campus_festival">
+  <h2>キャンフェスとは</h2>
+  <p>いるか知らんけどなんか書いていいんじゃない？文言は偉い人に考えて書いてもううとか？</p>
+</section>
+
+<section id="plan" class="plan_introduction">
+  <h2>企画紹介</h2>
+  <!--企画上がってきたのであとはステージ待ち-->
+  <div class="plan_group">
+    <h4>企画班</h4>
+    <ul>
+      <li>射的</li>
+      <li>フォトブース</li>
+      <li>プロジェクションマッピング</li>
+    </ul>
+  </div>
+  <div class="sell_group">
+    <h4>物販</h4>
+    <ul>
+      <li>パンケーキ</li>
+      <li>わらび餅ドリンク</li>
+      <li>週3物販</li>
+      <li>週1物販</li>
+    </ul>
+  </div>
+  <div class="stage_group">
+    <h4>ステージ</h4>
+    <ul>
+      <li>ComingSoon</li>
+    </ul>
+  </div>
+</section>
+
+<section id="timetable" class="time_tabel">
+  <h2>ステージタイムテーブル</h2>
+  <p>タイムテーブル作れ</p>
+</section>
+
+<section id="precautions" class="precautions">
+  <h2>注意事項</h2>
+  <ul>
+    <li>駐車場のご用意がございません、近隣のコインパーキングや公共交通機関をご利用ください</li>
+    <!--注意事項は要確認-->
+  </ul>
+</section>
+</main>
+<footer>
+  <h5>制作：福岡薬院万博広報部門web班</h5>
+</footer>
+
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const links = document.querySelectorAll('nav a');
+  links.forEach(link => {
+    link.addEventListener('click', () => {
+      links.forEach(l => l.classList.remove('active'));
+      link.classList.add('active');
+    });
+  });
+  console.log('Fukuoka Yakuin Expo site loaded');
+});


### PR DESCRIPTION
## Summary
- add navigation and semantic sections
- improve responsive layout and fonts
- highlight active menu item with JavaScript

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861e8aadad48324981667aba55344ce